### PR TITLE
better test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,55 @@
-# Changelog for project fj-doc-mod-openpdf
+# Changelog
 
-1.0.0 - 2023-08-30
-------------------
-* Updated parent version to fj-doc 1.5.4
-* Added license and maven repo central badge
+All notable changes to this project will be documented in this file.
 
-0.2.0 - 2023-08-20
-------------------
-* Updated parent version to fj-doc 1.5.0
-* Added sonar cloud quality gate (Deep code review)
-* Removed some deprecation notice by OpenPDF
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-0.1.0 - 2023-08-13
-------------------
-* Updated parent version to fj-doc 1.4.4
-* Typos in documentation
-* Added JUnit for basic testing
+## [Unreleased]
 
-0.1.0-rc.001 - 2023-07-22
-------------------
-* Porting of fj-doc-mod-itext based on [OpenPDF](https://github.com/LibrePDF/OpenPDF) / [OpenRTF](https://github.com/LibrePDF/OpenRTF)
+### Added
+
+- keep a changelog badge
+
+### Changed
+
+- fj-doc version set to 2.0.2
+- changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+
+## [1.0.0] - 2023-08-30
+
+### Added
+
+- Added license and maven repo central badge
+
+### Changed
+
+- Updated parent version to fj-doc 1.5.4
+
+## [0.2.0] - 2023-08-20
+
+### Added
+
+- Added sonar cloud quality gate (Deep code review)
+
+### Changed
+
+- Updated parent version to fj-doc 1.5.0
+- Refactor to avoid some deprecation notice by OpenPDF
+
+## [0.1.0] - 2023-08-13
+
+### Added
+
+- Added JUnit for basic testing
+
+### Changed
+
+- Updated parent version to fj-doc 1.4.4
+- Typos in documentation
+
+## [0.1.0-rc.001] - 2023-07-22
+
+### Added
+
+- Porting of fj-doc-mod-itext based on [OpenPDF](https://github.com/LibrePDF/OpenPDF) / [OpenRTF](https://github.com/LibrePDF/OpenRTF)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [back to fj-doc index](https://github.com/fugerit-org/fj-doc.git)  
 
+[![Keep a Changelog v1.1.0 badge](https://img.shields.io/badge/changelog-Keep%20a%20Changelog%20v1.1.0-%23E05735)](https://github.com/fugerit-org/fj-doc-mod-openpdf/blob/main/CHANGELOG.md) 
 [![Maven Central](https://img.shields.io/maven-central/v/org.fugerit.java/fj-doc-mod-openpdf.svg)](https://mvnrepository.com/artifact/org.fugerit.java/fj-doc-mod-openpdf) 
 [![license](https://img.shields.io/badge/License-Apache%20License%202.0-teal.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=fugerit-org_fj-doc-mod-openpdf&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=fugerit-org_fj-doc-mod-openpdf)

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
 	<parent>
 		<groupId>org.fugerit.java</groupId>
 		<artifactId>fj-doc</artifactId>
-		<version>1.5.4</version>
+		<version>2.0.2</version>
 		<relativePath></relativePath>
 	</parent>
 
 	<name>fj-doc-mod-openpdf</name>
 	<description>Fugerit DOC module for output in PDF, RTF and HTML using OpenPDF (Itext fork)</description>
-	<version>1.0.0</version>
+	<version>1.0.1-SNAPSHOT</version>
 
 	<licenses>
 		<license>

--- a/src/test/java/test/org/fugerit/java/doc/mod/itext/poc/TestDefaultDoc.java
+++ b/src/test/java/test/org/fugerit/java/doc/mod/itext/poc/TestDefaultDoc.java
@@ -1,6 +1,8 @@
 package test.org.fugerit.java.doc.mod.itext.poc;
 
+import org.fugerit.java.doc.mod.openpdf.HtmlTypeHandler;
 import org.fugerit.java.doc.mod.openpdf.PdfTypeHandler;
+import org.fugerit.java.doc.mod.openpdf.RtfTypeHandler;
 import org.junit.Test;
 
 public class TestDefaultDoc extends TestDocBase {
@@ -8,6 +10,16 @@ public class TestDefaultDoc extends TestDocBase {
 	@Test
 	public void testOpenPDF() {
 		this.testDocWorker( "default_doc" ,  PdfTypeHandler.HANDLER );
+	}
+
+	@Test
+	public void testOpenHTML() {
+		this.testDocWorker( "default_doc" ,  HtmlTypeHandler.HANDLER );
+	}
+	
+	@Test
+	public void testOpenRTF() {
+		this.testDocWorker( "default_doc" ,  RtfTypeHandler.HANDLER );
 	}
 	
 }


### PR DESCRIPTION
- keep a changelog badge
- fj-doc version set to 2.0.2
- changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)